### PR TITLE
removed unnecessary print statement

### DIFF
--- a/lua/intellitab/init.lua
+++ b/lua/intellitab/init.lua
@@ -59,7 +59,6 @@ local function indent()
         i = i + shiftwidth
       end
     end
-    print(i, indent_goal)
   else
     v.nvim_feedkeys(tab_char, 'n', true)
   end


### PR DESCRIPTION
Looks like a left-over debug statement; unnecessary to see the tab amount each time intellitab.indent() runs.